### PR TITLE
Support more than 9 controls

### DIFF
--- a/lib/parser-utils.js
+++ b/lib/parser-utils.js
@@ -73,7 +73,7 @@ function valuesLineParser (string, valuesType, result) {
 
 function itemLineParser (string) {
 	let item;
-	item = string.match (/^Item #\d '(.*?)'$/)[1]
+	item = string.match (/^Item #\d+ '(.*?)'$/)[1]
 	return item;
 }
 


### PR DESCRIPTION
I have change the regexp in itemLineParser to support cards with more than 9 controls, otherwise it will fail with this cards.